### PR TITLE
Adjust printf(...) statements to use inttypes types

### DIFF
--- a/source/CborBase.cpp
+++ b/source/CborBase.cpp
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <list>
+#include <inttypes.h>
 
 CborBase CborNull;
 
@@ -137,11 +138,11 @@ void CborBase::printQueue(std::list<CborBase*> queue)
                 uint32_t subtag = currentObject->getTag();
                 if (subtag != TypeUnassigned)
                 {
-                    printf("[%lu] ", subtag);
+                    printf("[%" PRIu32 "] ", subtag);
                 }
 
                 uint32_t items = currentObject->getSize();
-                printf("Array: %lu\r\n", items);
+                printf("Array: %" PRIu32 "\r\n", items);
 
                 if (items > 0)
                 {
@@ -163,11 +164,11 @@ void CborBase::printQueue(std::list<CborBase*> queue)
                 uint32_t subtag = currentObject->getTag();
                 if (subtag != TypeUnassigned)
                 {
-                    printf("[%lu] ", subtag);
+                    printf("[%" PRIu32 "] ", subtag);
                 }
 
                 uint32_t items = currentObject->getSize();
-                printf("Map: %lu\r\n", items);
+                printf("Map: %" PRIu32 "\r\n", items);
 
                 if (items > 0)
                 {
@@ -280,7 +281,7 @@ void CborBase::print()
     // write tag if set
     if (tag != TypeUnassigned)
     {
-        printf("(%lu) ", tag);
+        printf("(%" PRIu32 ") ", tag);
     }
 
     printf("null\r\n");

--- a/source/Cborg.cpp
+++ b/source/Cborg.cpp
@@ -18,6 +18,7 @@
 
 #include <list>
 #include <stdio.h>
+#include <inttypes.h>
 
 #if 0
 #include <stdio.h>
@@ -958,7 +959,7 @@ void Cborg::print() const
 
         if (tag != CborBase::TypeUnassigned)
         {
-            printf("[%lu] ", tag);
+            printf("[%" PRIu32 "] ", tag);
         }
 
         /* container object */
@@ -973,7 +974,7 @@ void Cborg::print() const
             }
             else if (head.getValue() > 0)
             {
-                printf("Map: %lu\r\n", head.getValue());
+                printf("Map: %" PRIu32 "\r\n", head.getValue());
 
                 list.push_back(units);
                 units = 2 * head.getValue();
@@ -990,7 +991,7 @@ void Cborg::print() const
             }
             else if (head.getValue() > 0)
             {
-                printf("Array: %lu\r\n", head.getValue());
+                printf("Array: %" PRIu32 "\r\n", head.getValue());
 
                 list.push_back(units);
                 units = head.getValue();
@@ -1022,7 +1023,7 @@ void Cborg::print() const
 
                         if (result)
                         {
-                            printf("%lu\r\n", integer);
+                            printf("%" PRIu32 "\r\n", integer);
                         }
                         else
                         {
@@ -1039,7 +1040,7 @@ void Cborg::print() const
 
                         if (result)
                         {
-                            printf("%ld\r\n", integer);
+                            printf("%" PRIi32 "\r\n", integer);
                         }
                         else
                         {


### PR DESCRIPTION
This ensures that cross compilation to different architectures uses
the correct printf(...) format specifiers without causing issues.

Signed-off-by: Tim Nordell <tim.nordell@nimbelink.com>